### PR TITLE
Issue 138: juicer-admin show-repo usage incorrect

### DIFF
--- a/juicer/admin/Parser.py
+++ b/juicer/admin/Parser.py
@@ -178,6 +178,7 @@ class Parser(object):
         # Create the 'show_repo' sub-parser
 
         parser_show_repo = self.subparsers.add_parser('show-repo', \
+                usage='%(prog)s name --in [ENV ...]', \
                 help='Show pulp repository')
 
         parser_show_repo.add_argument('name', metavar='name', \


### PR DESCRIPTION
Url: https://github.com/juicer/juicer/issues/138
-Explicitly states  the usage and positioning of --in option
Signed-off-by: Ameya Sathe aakreet40-rhce@yahoo.com

Please merge this commit into the master branch to fix the Issue 138 seen in version 0.6.1 of juicer-admin
