### PR TITLE
updated to work with latest pymongo version

### DIFF
--- a/juicer/utils/__init__.py
+++ b/juicer/utils/__init__.py
@@ -43,7 +43,7 @@ try:
     import json
 except ImportError:
     import simplejson as json
-from pymongo import Connection as MongoClient
+from pymongo import MongoClient
 from pymongo import errors as MongoErrors
 
 


### PR DESCRIPTION
Connection is now obsolete:

# Error:
\# juicer hello
```
Traceback (most recent call last):
  File "/bin/juicer", line 19, in <module>
    import juicer.juicer
  File "/usr/lib/python2.7/site-packages/juicer/juicer/__init__.py", line 18, in <module>
    import juicer.utils.Log
  File "/usr/lib/python2.7/site-packages/juicer/utils/__init__.py", line 44, in <module>
    from pymongo import Connection as MongoClient
ImportError: cannot import name Connection
```


# Details:
According to  changes (http://api.mongodb.com/python/current/changelog.html#mongoclient-changes)

> MongoClient is now the one and only client class for a standalone server, mongos, or replica set. It includes the functionality that had been split into MongoReplicaSetClient: it can connect to a replica set, discover all its members, and monitor the set for stepdowns, elections, and reconfigs. MongoClient now also supports the full ReadPreference API.
> 
>     The obsolete classes MasterSlaveConnection, Connection, and ReplicaSetConnection are removed.