### PR TITLE
BeautifulSoup class name changed for newer distros

### DIFF
--- a/juicer/utils/Remotes.py
+++ b/juicer/utils/Remotes.py
@@ -12,7 +12,13 @@
 """
 Functions for handling remote package resources
 """
-from BeautifulSoup import BeautifulSoup as bs
+try:
+    from BeautifulSoup import BeautifulSoup as bs
+except ImportError:
+    try:
+        from bs4 import BeautifulSoup as bs
+    except:
+        print "Failed to import BeautifulSoup."
 from os.path import exists, expanduser
 import re
 import urllib2


### PR DESCRIPTION
The current code references BeautifulSoup but newer classes are renamed to bs4. This PR compensates for that by using try/except so that older distros can continue to use the software.